### PR TITLE
OpenMP2 task

### DIFF
--- a/OpenMP2/src/main.cpp
+++ b/OpenMP2/src/main.cpp
@@ -5,7 +5,25 @@
 
 double calc(uint32_t x_last, uint32_t num_threads)
 {
-  return 0;
+  double* sum = (double*)calloc(num_threads, sizeof(double));
+  double* err = (double*)calloc(num_threads, sizeof(double));
+
+  #pragma omp parallel for num_threads(num_threads)
+  for(uint32_t i = 1; i <= x_last; i++)
+  {
+  	double t = sum[omp_get_thread_num()] + 1 / (double) i;
+    err[omp_get_thread_num()] += sum[omp_get_thread_num()] - t + 1 / (double) i;
+    sum[omp_get_thread_num()] = t;
+  }
+
+  double res = 0;
+  for(uint32_t i = 0; i < num_threads; ++i)
+  {
+    res += err[i] + sum[i];
+  }
+  free(err);
+  free(sum);
+  return res;
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
[TEST 00] OK (4 ms)
[TEST 01] OK (6 ms)
[TEST 02] OK (18 ms)
[TEST 03] DIFF FAIL(2141 ms): my(18.9978964138539) / your(18.9978964138534)
[TEST 04] DIFF FAIL(1169 ms): my(18.9978964138539) / your(18.9978964138534)

The result of a command _sum 1 / n from 1 to 100000000_ in wolfram alpha - **18.9978964138538**9832... That is why I think my result is more accurate. 
My machine have 2 logical cores.
